### PR TITLE
Added multiple ethernet adapter support

### DIFF
--- a/ucs-tool.ps1
+++ b/ucs-tool.ps1
@@ -264,7 +264,7 @@ Function GetDriverDetails {
         {
             continue
         }
-        if(!$driverList.contains($osInv.Value)) {
+        if((!$driverList.Contains($osInv.Value)) -or (!$driverNameList.Contains($storageController.DeviceName))) {
             $driverList.Add($osInv.Value)
             $count = $osInvCollection.Add($osInv)
             Clear-Variable -Name osInv


### PR DESCRIPTION
Issue: Adapter of same type is not getting included in the output. 
Fix: if the adapter name varies, then included it in the output.