### PR TITLE
updated nvidia-smi command line arguments

### DIFF
--- a/ucs-tool.ps1
+++ b/ucs-tool.ps1
@@ -231,7 +231,7 @@ Function GetDriverDetails {
                 foreach($cmd in $nvidiasmi)
                 {
                     # Determine if Graphics driver or compute driver is installed
-                    $command = "'$cmd' --query-gpu=driver_model.current --format=csv,no header"
+                    $command = "'$cmd' --query-gpu=driver_model.current --format='csv,noheader'"
                     $mode = Invoke-Command -ComputerName $hostname -ScriptBlock ([ScriptBlock]::Create("& $command"))
 
                     if($mode -contains "WDDM")


### PR DESCRIPTION
nvidia output format wrongly specified.
wrong format: --format=csv, no header
right format: --format='csv,noheader'

root cause: 'noheader' is a single word, but earlier it was specified as 'no header' which caused the issue.