### PR TITLE
Nvidia bluefield adapter support missing in windows ODT

### DIFF
--- a/ucs-tool.ps1
+++ b/ucs-tool.ps1
@@ -147,7 +147,7 @@ Function GetDriverDetails {
     $driverNameList = New-Object Collections.Generic.List[string]
     #vNIC details
     Write-host "[$hostname]: Retrieving Network Driver Inventory..."
-    $netDevList = Get-CimInstance Win32_PnPSignedDriver -Computer $hostname | select DeviceName, FriendlyName,DriverVersion, Description |
+    $netDevList = Get-CimInstance Win32_PnPSignedDriver -Computer $hostname | select DeviceName, FriendlyName, DriverVersion, Description, DeviceClass |
                     where {
                         $_.Devicename -like "*Ethernet*" -or
                         $_.Devicename -like "*FCoE*" -or
@@ -220,7 +220,13 @@ Function GetDriverDetails {
         {
             $osInv | Add-Member -type NoteProperty -name Value -Value "Ethernet"
         }
-        elseif($netdev.DeviceName -like "*Nvidia*")
+        elseif($netdev.DeviceName -like "*Nvidia*" -and $netdev.DeviceClass -eq "NET")
+        {
+            $netdrivername = (Get-CimInstance -class "Win32_NetworkAdapter" -namespace "root\CIMV2" -ComputerName $hostname) | select Name, MACAddress, ServiceName |
+                    where { $_.Name -eq $netdev.FriendlyName -and $_.MACAddress}
+            $osInv | Add-Member -type NoteProperty -name Value -Value $netdrivername.ServiceName
+        }
+        elseif($netdev.DeviceName -like "*Nvidia*" -and $netdev.DeviceClass -eq "DISPLAY")
         {
             Write-host "[$hostname]: NVIDIA GPU Detected, retrieving GPU inventory..."
 
@@ -279,7 +285,7 @@ Function GetDriverDetails {
             $key = $prefix+"os.driver."+$devcount+".version"
 
             # Nvidia GPU driver version needs special reformatting
-            if($netdev.DeviceName -like "*Nvidia*")
+            if($netdev.DeviceName -like "*Nvidia*" -and $netdev.DeviceClass -eq "DISPLAY")
             {
                 $osInv | Add-Member -type NoteProperty -name Key -Value $key
 


### PR DESCRIPTION
Earlier Nvidia GPU alone supported, in which the regex used was "Nvidia", but Nvidia network adapters also matched the same condition and hence caused the issue. 

Fix: properly filtered the Network adapters and Display devices and retrived the data accordingly