### PR TITLE
Timestamp format change

### DIFF
--- a/ucs-tool.ps1
+++ b/ucs-tool.ps1
@@ -68,7 +68,7 @@ Function GetTAGPrefix {
 }
 
 Function GetISO8601Time {
-    return ((Get-Date).ToUniversalTime().ToString( "yyyy-MM-ddTHH:mm:ss.fffZ" ))
+    return Get-Date -Format "yyyy-MM-ddTHH:mm:ssK"
 }
 
 Function GetOSDetails{


### PR DESCRIPTION
Linux and ESXi use the timestamp format "yyyy-MM-ddTHH:mm:ssK," while Windows ODT uses "yyyy-MM-ddTHH:mm:ssZ." In Mustang servers, the timestamp is expected to match that of Linux and ESXi; hence, this change is necessary.