### PR TITLE
Added support for nvidia gpu MCDM mode

### DIFF
--- a/ucs-tool.ps1
+++ b/ucs-tool.ps1
@@ -255,7 +255,7 @@ Function GetDriverDetails {
                         Write-host "[$hostname]: NVIDIA Graphics Driver is installed"
                         $osInv | Add-Member -type NoteProperty -name Value -Value "nvidia(graphics)"
                     }
-                    elseif($mode -contains "TCC")
+                    elseif(($mode -contains "TCC") -or ($mode -contains "MCDM"))
                     {
                         Write-host "[$hostname]: NVIDIA Compute Driver is installed"
                         $osInv | Add-Member -type NoteProperty -name Value -Value "nvidia(compute)"


### PR DESCRIPTION
ISSUE: driver name is not getting populated when the gpu was in MCDM mode.
Fix: driver name set as nvidia(compute) when it is configured in MCDM mode.
host-inv.yaml output:
```
 -kv:
  key: os.driver.0.name
  value: nvidia(compute)
 -kv:
  key: os.driver.0.description
  value: NVIDIA RTX PRO 4500 Blackwell Server Edition
 -kv:
  key: os.driver.0.version
  value: 595.97
```