### PR TITLE
Added support for UCSC-RAID-MP1L32 Controller

### DIFF
--- a/ucs-tool.ps1
+++ b/ucs-tool.ps1
@@ -375,6 +375,7 @@ Function GetDriverDetails {
                 $storageController.DeviceName -like "*Mega*") -or
                 $storageController.DeviceName -like "*SAS RAID*" -or
                 $storageController.DeviceName -like "*RAID SAS*" -or
+                $storageController.DeviceName -like "*UCSC-RAID*" -or
                 $storageController.DeviceName -like "*RAID Controller*")
         {
             if ($storageController.DeviceName -like "*Tri-Mode*")


### PR DESCRIPTION
Added support for UCSC-RAID-MP1L32 Controller

example host-inv.yaml file output:
```
 -kv:
  key: os.driver.10.name
  value: SmartPqi
 -kv:
  key: os.driver.10.description
  value: Cisco 24G TriMode M1 RAID 4GB FBWC 32D UCSC-RAID-MP1L32 Controller
 -kv:
  key: os.driver.10.version
  value: 1016.38.0.1003
```